### PR TITLE
feat: add configuration setter for TestHelpers

### DIFF
--- a/lib/bidi2pdf/test_helpers/configuration.rb
+++ b/lib/bidi2pdf/test_helpers/configuration.rb
@@ -47,6 +47,10 @@ module Bidi2pdf
         @configuration ||= Configuration.new
       end
 
+      # Sets the configuration object for TestHelpers.
+      # @param [Configuration] config the configuration object to set
+      attr_writer :configuration
+
       # Allows configuration of TestHelpers by yielding the configuration object.
       # @yieldparam [Configuration] configuration the configuration object to modify
       def configure


### PR DESCRIPTION
Introduces a setter method for the configuration object in TestHelpers. This allows users to set a custom configuration object, enhancing flexibility in test setups.