### PR TITLE
feat: expand default Chrome arguments for sessions

### DIFF
--- a/lib/bidi2pdf/bidi/commands.rb
+++ b/lib/bidi2pdf/bidi/commands.rb
@@ -18,6 +18,8 @@ module Bidi2pdf
       require_relative "commands/browsing_context_close"
       require_relative "commands/browsing_context_navigate"
       require_relative "commands/browsing_context_print"
+      require_relative "commands/cdp_get_session"
+      require_relative "commands/page_print"
       require_relative "commands/session_subscribe"
       require_relative "commands/session_end"
       require_relative "commands/cancel_auth"

--- a/lib/bidi2pdf/bidi/commands/cdp_get_session.rb
+++ b/lib/bidi2pdf/bidi/commands/cdp_get_session.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Bidi2pdf
+  module Bidi
+    module Commands
+      class CdpGetSession
+        include Base
+
+        def initialize(context:)
+          @context = context
+        end
+
+        def params = { context: @context }
+
+        def method_name
+          "goog:cdp.getSession"
+        end
+      end
+    end
+  end
+end

--- a/lib/bidi2pdf/bidi/commands/page_print.rb
+++ b/lib/bidi2pdf/bidi/commands/page_print.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+require_relative "print_parameters_validator"
+
+module Bidi2pdf
+  module Bidi
+    module Commands
+      class PagePrint
+        include Base
+
+        def initialize(cdp_session:, print_options:)
+          @cdp_session = cdp_session
+          @print_options = print_options || { background: true }
+
+          PrintParametersValidator.validate!(@print_options)
+
+          return unless @print_options[:page]&.key?(:format)
+
+          @print_options[:page] = Bidi2pdf.translate_paper_format @print_options[:page][:format]
+        end
+
+        # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+        def params
+          {
+            # https://chromedevtools.github.io/devtools-protocol/tot/Page/#method-printToPDF
+            method: "Page.printToPDF",
+            session: @cdp_session,
+            params: {
+              "printBackground" => @print_options[:background],
+
+              "marginTop" => cm_to_inch(@print_options.dig(:margin, :top) || 0),
+              "marginBottom" => cm_to_inch(@print_options.dig(:margin, :bottom) || 0),
+              "marginLeft" => cm_to_inch(@print_options.dig(:margin, :left) || 0),
+              "marginRight" => cm_to_inch(@print_options.dig(:margin, :right) || 0),
+              "landscape" => (@print_options[:orientation] || "portrait").to_sym == :landscape,
+
+              "paperWidth" => cm_to_inch(@print_options.dig(:page, :width)),
+              "paperHeight" => cm_to_inch(@print_options.dig(:page, :height)),
+              "pageRanges" => page_ranges_to_string(@print_options[:pageRanges]),
+              "scale" => @print_options[:scale] || 1.0,
+
+              "displayHeaderFooter" => @print_options[:display_header_footer],
+              "headerTemplate" => @print_options[:header_template] || "",
+              "footerTemplate" => @print_options[:footer_template] || "",
+
+              "preferCSSPageSize" => @print_options.fetch(:prefer_css_page_size, true),
+
+              "generateTaggedPDF" => @print_options.fetch(:generate_tagged_pdf, false),
+              "generateDocumentOutline" => @print_options.fetch(:generate_document_outline, false),
+
+              transferMode: "ReturnAsBase64"
+            }.compact
+          }
+        end
+
+        # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+
+        def method_name
+          "goog:cdp.sendCommand"
+        end
+
+        private
+
+        # rubocop:disable  Naming/MethodParameterName
+        def cm_to_inch(cm)
+          return nil if cm.nil?
+
+          cm.to_f / 2.54
+        end
+
+        # rubocop:enable  Naming/MethodParameterName
+
+        # rubocop:disable Metrics/CyclomaticComplexity
+        def page_ranges_to_string(input)
+          return nil if input.nil? || input.empty?
+
+          segments = input.map do |entry|
+            case entry
+            when Integer
+              entry.to_s
+            when String
+              raise ArgumentError, "Invalid page entry: #{entry.inspect}" unless entry =~ /\A\d+(-\d+)?\z/
+
+              entry
+            else
+              raise ArgumentError, "Unsupported page entry type: #{entry.class}"
+            end
+          end
+
+          # dedupe, sort by numeric start, and join
+          segments
+            .uniq
+            .sort_by { |seg| seg.split("-", 2).first.to_i }
+            .join(",")
+        end
+
+        # rubocop:enable Metrics/CyclomaticComplexity
+      end
+    end
+  end
+end

--- a/lib/bidi2pdf/bidi/session.rb
+++ b/lib/bidi2pdf/bidi/session.rb
@@ -32,7 +32,38 @@ module Bidi2pdf
       SUBSCRIBE_EVENTS = %w[script].freeze
 
       # Default Chrome arguments for the session.
-      DEFAULT_CHROME_ARGS = %w[--disable-gpu --disable-popup-blocking --disable-hang-monitor].freeze
+      DEFAULT_CHROME_ARGS = [
+        "--allow-pre-commit-input", # Allow pre-commit input for form fields
+        "--disable-dev-shm-usage", # Disable /dev/shm usage; use /tmp instead
+        "--disable-gpu", # Disable GPU hardware acceleration; force software rendering
+        "--disable-popup-blocking", # Allow all pop-ups; bypass built-in popup blocker
+        "--disable-hang-monitor", # Disable “Page Unresponsive” / “Aw, Snap!” dialogs on hangs
+        "--disable-background-networking", # Turn off speculative/periodic network requests (DNS prefetch, Safe Browsing updates, etc.)
+        "--disable-background-timer-throttling", # Prevent JS timers from being throttled in background tabs
+        "--disable-client-side-phishing-detection", # Disable built-in phishing checks; rely only on server-side detection
+        "--disable-component-extensions-with-background-pages", # Block component extensions that run persistent background pages (PDF viewer, Translate, etc.)
+        "--disable-crash-reporter", # Disable crash-report uploads and UI
+        "--disable-default-apps", # Stop installation of Chrome’s default apps on a fresh profile
+        "--disable-infobars", # Suppress “Chrome is being controlled by automated test software” infobar (and similar)
+        "--disable-ipc-flooding-protection", # Turn off defenses against too-many IPC messages from renderers
+        "--disable-prompt-on-repost", # Skip “Confirm Form Resubmission” dialogs on page reloads after POST
+        "--disable-renderer-backgrounding", # Keep background tab renderers at full priority
+        "--disable-search-engine-choice-screen", # Skip first-run search engine selection UI
+        "--disable-sync", # Turn off all Google account sync (bookmarks, passwords, etc.)
+        "--enable-automation", # Expose WebDriver hooks (navigator.webdriver) for automation frameworks
+        "--export-tagged-pdf", # When printing to PDF, include tagged structure for accessibility
+        "--force-color-profile=srgb", # Force rendering to use the sRGB color profile
+        "--generate-pdf-document-outline", # Auto-generate PDF bookmarks/outlines from HTML headings, not supported by chrome/chromium https://issues.chromium.org/issues/41387522#comment48
+        "--metrics-recording-only", # Collect UMA metrics locally but never upload them
+        "--no-first-run", # Skip the “Welcome” or “What’s New” screens on fresh profiles
+        "--password-store=basic", # Use Chrome’s basic (in-profile) password storage vs. OS vault
+        "--use-mock-keychain", # On macOS, use a fake keychain for testing (don’t touch the real one)
+        "--disable-backgrounding-occluded-windows", # Prevent fully-occluded windows from being treated as background
+        "--disable-breakpad", # Disable the Breakpad crash-reporting library entirely
+        "--enable-features=PdfOopif", # Enable out-of-process iframe (OOPIF) architecture for PDF rendering
+        "--disable-features=Translate,AcceptCHFrame,MediaRouter,OptimizationHints,ProcessPerSiteUpToMainFrameThreshold,IsolateSandboxedIframes",
+        "--disable-extensions about:blank"
+      ].freeze
 
       # @return [URI] The URI of the session.
       attr_reader :session_uri
@@ -209,7 +240,7 @@ module Bidi2pdf
       # @return [Hash] The session request payload.
       def session_request
         session_chrome_args = chrome_args.dup
-        session_chrome_args << "--headless" if @headless
+        session_chrome_args << "--headless=new" if @headless
 
         {
           "capabilities" => {

--- a/lib/bidi2pdf/cli.rb
+++ b/lib/bidi2pdf/cli.rb
@@ -74,6 +74,8 @@ module Bidi2pdf
     option :page_ranges, type: :array, desc: "Page ranges to print (e.g., 1-2 4 6)"
     option :scale, type: :numeric, default: 1.0, desc: "Scale between 0.1 and 2.0"
     option :shrink_to_fit, type: :boolean, default: true, desc: "Shrink content to fit page"
+    option :generate_tagged_pdf, type: :boolean, default: false, desc: "Generate tagged PDF"
+    option :generate_document_outline, type: :boolean, default: false, desc: "Generate document outline"
 
     class << self
       def exit_on_failure?
@@ -150,7 +152,7 @@ module Bidi2pdf
       raise Thor::Error, "Invalid print option: #{e.message}"
     end
 
-    # rubocop:disable Metrics/CyclomaticComplexity
+    # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
     def print_options
       opts = {}
 
@@ -186,10 +188,15 @@ module Bidi2pdf
       assign_if_provided(page, :height, :page_height)
       opts[:page] = page unless page.empty?
 
+      assign_if_provided(opts, :generate_tagged_pdf)
+      assign_if_provided(opts, :generate_document_outline)
+
+      opts[:cmd_type] = :cdp if opts[:generate_tagged_pdf] || opts[:generate_document_outline]
+
       opts.empty? ? nil : opts
     end
 
-    # rubocop:enable Metrics/CyclomaticComplexity
+    # rubocop:enable Metrics/CyclomaticComplexity,  Metrics/PerceivedComplexity
 
     def option_provided?(key)
       ARGV.include?("--#{key.to_s.tr("_", "-")}") || ARGV.include?("--#{key}")


### PR DESCRIPTION
Add additional default Chrome arguments to enhance automation and testing capabilities. These changes improve performance, security, and user experience during automated browser sessions.

Add cdp Page.PrintToPdf command in order to get more options e.g. pdf tags and outlines