### PR TITLE
chore: clean up action.yml configuration

### DIFF
--- a/.github/actions/setup-ruby/action.yml
+++ b/.github/actions/setup-ruby/action.yml
@@ -14,4 +14,3 @@ runs:
       with:
         ruby-version: .ruby-version
         bundler-cache: true
-        bundler-install-args: --jobs 4 --retry 3


### PR DESCRIPTION
Removed unnecessary bundler-install-args from the action.yml file. This simplifies the configuration while maintaining bundler caching.