### PR TITLE
chore: remove Code Climate coverage report workflow

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -72,40 +72,6 @@ jobs:
       test_tag: acceptance
       artifact_name: acceptance-coverage
       upload_pdf: true
-  
-  coverage-report:
-    needs:
-      - unit-test
-      - integration-test
-      - acceptance-test
-    runs-on: ubuntu-latest
-    env:
-      CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
-    steps:
-      - uses: actions/checkout@v3
-      - name: Setup Ruby Environment
-        uses: ./.github/actions/setup-ruby
-      - name: Download all coverage artifacts
-        uses: actions/download-artifact@v4
-        with:
-          # only path means download all artifacts to this dir
-          path: coverage-artifacts
-      - name: Combine coverage reports
-        run: |
-          mkdir -p coverage
-          ls  -ltraR coverage-artifacts          
-          cp coverage-artifacts/unit-coverage/.resultset.json coverage/unit-resultset.json
-          cp coverage-artifacts/integration-coverage/.resultset.json coverage/integration-resultset.json
-          cp coverage-artifacts/acceptance-coverage/.resultset.json coverage/acceptance-resultset.json
-          bundle exec rake coverage:merge_reports
-      - name: Upload coverage to Code Climate
-        if: ${{ github.event_name != 'pull_request' }}
-        uses: paambaati/codeclimate-action@v3.2.0
-      - name: Upload coverage report
-        uses: actions/upload-artifact@v4
-        with:
-          name: coverage-report
-          path: coverage/
 
   push_cli_to_registry:
     if: ${{ github.event_name != 'pull_request' }}

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 [![Build Status](https://github.com/dieter-medium/bidi2pdf/actions/workflows/ruby.yml/badge.svg)](https://github.com/dieter-medium/bidi2pdf/blob/main/.github/workflows/ruby.yml)
 [![Maintainability](https://api.codeclimate.com/v1/badges/6425d9893aa3a9ca243e/maintainability)](https://codeclimate.com/github/dieter-medium/bidi2pdf/maintainability)
 [![Gem Version](https://badge.fury.io/rb/bidi2pdf.svg)](https://badge.fury.io/rb/bidi2pdf)
-[![Test Coverage](https://api.codeclimate.com/v1/badges/6425d9893aa3a9ca243e/test_coverage)](https://codeclimate.com/github/dieter-medium/bidi2pdf/test_coverage)
 [![Open Source Helpers](https://www.codetriage.com/dieter-medium/bidi2pdf/badges/users.svg)](https://www.codetriage.com/dieter-medium/bidi2pdf)
 
 ---


### PR DESCRIPTION
This commit deletes the coverage report workflow from the CI configuration. I don't want to migrate to Qlty